### PR TITLE
Change wrong subServer string

### DIFF
--- a/bukkit/src/main/java/de/staticred/dbverifier/DBVerifier.java
+++ b/bukkit/src/main/java/de/staticred/dbverifier/DBVerifier.java
@@ -81,7 +81,7 @@ public class DBVerifier extends JavaPlugin implements PluginMessageListener {
             String uuid = jsonObject.getString("uuid");
 
             boolean verified = srv.getAccountLinkManager().getDiscordId(UUID.fromString(uuid)) == null;
-            sendToBungee(player,"test","{\"uuid\": \"" + uuid + "\", \"verified\": " + verified + "}");
+            sendToBungee(player, "requestAnswer", "{\"uuid\": \"" + uuid + "\", \"verified\": " + verified + "}");
 
 
         }


### PR DESCRIPTION
Fix error for login and !verify command

`[WARNING] Error dispatching event PluginMessageEvent(super=TargetedEvent(sender=net.md_5.bungee.ServerConnection@e7e1ce, receiver=Exca_Drill), cancelled=false, tag=dbv:bungeecord) to listener de.staticred.discordbot.bukkitconnectionhandler.BukkitMessageHandler@38291795
org.json.JSONException: JSONObject["test"] not found.`