### PR TITLE
Catch HierarchyException and add debug message

### DIFF
--- a/bungeecord/src/main/java/de/staticred/discordbot/bungeecommands/MCVerifyCommandExecutor.java
+++ b/bungeecord/src/main/java/de/staticred/discordbot/bungeecommands/MCVerifyCommandExecutor.java
@@ -16,6 +16,7 @@ import de.staticred.discordbot.util.MemberManager;
 import net.dv8tion.jda.api.entities.Member;
 import net.dv8tion.jda.api.entities.TextChannel;
 import net.dv8tion.jda.api.entities.User;
+import net.dv8tion.jda.api.exceptions.HierarchyException;
 import net.md_5.bungee.api.CommandSender;
 import net.md_5.bungee.api.ProxyServer;
 import net.md_5.bungee.api.chat.TextComponent;
@@ -125,6 +126,8 @@ public class MCVerifyCommandExecutor extends Command {
                 }
             } catch (SQLException throwables) {
                 throwables.printStackTrace();
+            } catch (HierarchyException e) {
+                Debugger.debugMessage("Can't modify a member with higher or equal highest role than the bot! Can't modify " + m.getNickname());
             }
 
             p.sendMessage(new TextComponent(DBVerifier.getInstance().getStringFromConfig("Verified",true)));
@@ -186,7 +189,11 @@ public class MCVerifyCommandExecutor extends Command {
                 if (m.isOwner()) {
                     p.sendMessage(new TextComponent(DBVerifier.getInstance().getStringFromConfig("MemberIsOwner", false)));
                 } else {
-                    m.getGuild().modifyNickname(m, p.getName()).queue();
+                    try {
+                        m.getGuild().modifyNickname(m, p.getName()).queue();
+                    } catch (HierarchyException e) {
+                        Debugger.debugMessage("Can't modify a member with higher or equal highest role than the bot! Can't modify " + m.getNickname());
+                    }
                 }
 
             }

--- a/bungeecord/src/main/java/de/staticred/discordbot/bungeeevents/PostLoginEvent.java
+++ b/bungeecord/src/main/java/de/staticred/discordbot/bungeeevents/PostLoginEvent.java
@@ -9,6 +9,7 @@ import de.staticred.discordbot.files.SettingsFileManager;
 import de.staticred.discordbot.util.Debugger;
 import de.staticred.discordbot.util.MemberManager;
 import net.dv8tion.jda.api.entities.Member;
+import net.dv8tion.jda.api.exceptions.HierarchyException;
 import net.md_5.bungee.api.ProxyServer;
 import net.md_5.bungee.api.chat.ClickEvent;
 import net.md_5.bungee.api.chat.ComponentBuilder;
@@ -123,8 +124,12 @@ public class PostLoginEvent implements Listener {
 
 
                 if(DBVerifier.INSTANCE.syncNickname) {
-                    if(!m.isOwner()) {
-                        m.getGuild().modifyNickname(m, player.getName()).queue();
+                    try {
+                        if (!m.isOwner()) {
+                            m.getGuild().modifyNickname(m, player.getName()).queue();
+                        }
+                    } catch (HierarchyException e) {
+                        Debugger.debugMessage("Can't modify a member with higher or equal highest role than the bot! Can't modify " + m.getNickname());
                     }
                 }
 

--- a/bungeecord/src/main/java/de/staticred/discordbot/util/MemberManager.java
+++ b/bungeecord/src/main/java/de/staticred/discordbot/util/MemberManager.java
@@ -9,6 +9,7 @@ import de.staticred.discordbot.files.DiscordFileManager;
 import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.entities.Member;
 import net.dv8tion.jda.api.entities.User;
+import net.dv8tion.jda.api.exceptions.HierarchyException;
 import net.md_5.bungee.api.connection.ProxiedPlayer;
 
 import java.sql.SQLException;
@@ -79,6 +80,8 @@ public class MemberManager {
             }catch (NullPointerException | IndexOutOfBoundsException exception) {
                 Debugger.debugMessage("The Bot can't find the given Role. The Role the problem has occured: verify");
                 Debugger.debugMessage("UseIDs: " + ConfigFileManager.INSTANCE.useTokens());
+            } catch (HierarchyException e) {
+                Debugger.debugMessage("Can't modify a member with higher or equal highest role than the bot! Can't modify " + m.getNickname());
             }
 
         }
@@ -127,6 +130,8 @@ public class MemberManager {
                         Debugger.debugMessage("The Bot can't find the given Role. The Role the problem has occured: " + group);
                         Debugger.debugMessage("UseIDs: " + ConfigFileManager.INSTANCE.useTokens());
                         return;
+                    } catch (HierarchyException e) {
+                        Debugger.debugMessage("Can't modify a member with higher or equal highest role than the bot! Can't modify " + m.getNickname());
                     }
 
                 } else {


### PR DESCRIPTION
User doesn't get the message "an internal error occurred while executing this command, please check the console log for details", when the bot hasn't a higher Role than the user.