### PR TITLE
Fix DiscordSRV-Bot remove verified Role

### DIFF
--- a/bukkit/src/main/java/de/staticred/dbverifier/DBVerifier.java
+++ b/bukkit/src/main/java/de/staticred/dbverifier/DBVerifier.java
@@ -63,6 +63,10 @@ public class DBVerifier extends JavaPlugin implements PluginMessageListener {
             String uuid = jsonObject.getString("uuid");
             String discordID = jsonObject.getString("discordID");
 
+            if(srv.getAccountLinkManager().getDiscordId(UUID.fromString(uuid)) != null && srv.getAccountLinkManager().getDiscordId(UUID.fromString(uuid)).equals(discordID)){
+                return;
+            }
+
             srv.getAccountLinkManager().link(discordID, UUID.fromString(uuid));
             System.out.println("Linked " + name + " in srv");
         }


### PR DESCRIPTION
If you use DiscordSRV-Bots, they removed the verified role after server switching.