### PR TITLE
Catch NoClassDefFoundError and add debug mode

### DIFF
--- a/bukkit/src/main/java/de/staticred/dbverifier/DBVerifier.java
+++ b/bukkit/src/main/java/de/staticred/dbverifier/DBVerifier.java
@@ -23,6 +23,7 @@ public class DBVerifier extends JavaPlugin implements PluginMessageListener {
     DiscordSRV srv;
     YamlConfiguration conf;
     boolean useSRV;
+    boolean debugMode = false;
 
     //the name of the channel which is used to communicate with the bukkit subserver for a discordsrv connection
     public static final String PLUGIN_CHANNEL_NAME = "dbv:bungeecord";
@@ -33,86 +34,98 @@ public class DBVerifier extends JavaPlugin implements PluginMessageListener {
         loadConfig();
 
         useSRV = conf.getBoolean("useSRV");
-        if(useSRV) {
+        debugMode = conf.getBoolean("debugMode");
+
+        if (useSRV) {
             try {
                 srv = DiscordSRV.getPlugin();
-            }catch (NoClassDefFoundError e){
+            } catch (NoClassDefFoundError e) {
                 useSRV = false;
                 System.out.println("§c[DBVerifierLinker] DiscordSRV is not installed!");
+                if (debugMode)
+                    System.out.println("§c[DBVerifierLinker] DiscordSRV is not installed, please install DiscordSRV to use this feature.");
             }
         }
 
-
-
         getServer().getMessenger().registerOutgoingPluginChannel(this, PLUGIN_CHANNEL_NAME);
         getServer().getMessenger().registerIncomingPluginChannel(this, PLUGIN_CHANNEL_NAME, this);
-
     }
-
 
     @Override
     public void onPluginMessageReceived(@NotNull String channel, @NotNull Player player, @NotNull byte[] message) {
 
-        if(!channel.equals(PLUGIN_CHANNEL_NAME)) return;
+        if (!channel.equals(PLUGIN_CHANNEL_NAME)) return;
 
         ByteArrayDataInput in = ByteStreams.newDataInput(message);
 
         String subChannel = in.readUTF();
         String data = in.readUTF();
 
-        System.out.println("Received Data by BungeeCord: " + data + " SubChannel: " + subChannel);
+        if (debugMode)
+            System.out.println("§c[DBVerifierLinker] Received Data by BungeeCord: " + data + " SubChannel: " + subChannel);
 
         if (subChannel.equals("verified")) {
-            if(!useSRV) return;
+            if (!useSRV) {
+                if (debugMode)
+                    System.out.println("§c[DBVerifierLinker] DiscordSRV is not installed, please install DiscordSRV to use this feature.");
+                return;
+            }
+
             JSONObject jsonObject = new JSONObject(data);
 
             String name = jsonObject.getString("name");
             String uuid = jsonObject.getString("uuid");
             String discordID = jsonObject.getString("discordID");
 
-            if(srv.getAccountLinkManager().getDiscordId(UUID.fromString(uuid)) != null && srv.getAccountLinkManager().getDiscordId(UUID.fromString(uuid)).equals(discordID)){
+            if (srv.getAccountLinkManager().getDiscordId(UUID.fromString(uuid)) != null && srv.getAccountLinkManager().getDiscordId(UUID.fromString(uuid)).equals(discordID))
+                return;
+
+            srv.getAccountLinkManager().link(discordID, UUID.fromString(uuid));
+            if (debugMode) System.out.println("§c[DBVerifierLinker] Linked " + name + " in srv");
+        }
+
+        if (subChannel.equals("unlink")) {
+            if (!useSRV) {
+                if (debugMode)
+                    System.out.println("§c[DBVerifierLinker] DiscordSRV is not installed, please install DiscordSRV to use this feature.");
                 return;
             }
 
-            srv.getAccountLinkManager().link(discordID, UUID.fromString(uuid));
-            System.out.println("Linked " + name + " in srv");
-        }
-        if(subChannel.equals("unlink")) {
-            if(!useSRV) return;
             JSONObject jsonObject = new JSONObject(data);
 
             String name = jsonObject.getString("name");
             String uuid = jsonObject.getString("uuid");
 
             srv.getAccountLinkManager().unlink(UUID.fromString(uuid));
-            System.out.println("unlinked " + name + " in srv");
+
+            if (debugMode) System.out.println("§c[DBVerifierLinker] Unlinked " + name + " in srv");
         }
 
-        if(subChannel.equals("request")) {
+        if (subChannel.equals("request")) {
             JSONObject jsonObject = new JSONObject(data);
             String uuid = jsonObject.getString("uuid");
 
             boolean verified = true;
-            if(useSRV) {
+
+            if (useSRV) {
                 verified = srv.getAccountLinkManager().getDiscordId(UUID.fromString(uuid)) == null;
             }
+            if (debugMode) System.out.println("§c[DBVerifierLinker] Send request Answer to BungeeCord");
             sendToBungee(player, "requestAnswer", "{\"uuid\": \"" + uuid + "\", \"verified\": " + verified + "}");
-
-
         }
 
-        if(subChannel.equals("command")) {
+        if (subChannel.equals("command")) {
             JSONObject jsonObject = new JSONObject(data);
             String uuid = jsonObject.getString("uuid");
             String command = jsonObject.getString("command");
-            if(command.equals("")) return;
+            if (command.equals("")) return;
             String name = jsonObject.getString("name");
-            System.out.println("Received command from bungeecord: " + command);
-            Bukkit.dispatchCommand(Bukkit.getConsoleSender(),command.replaceAll("%player%",name));
+            if (debugMode) System.out.println("§c[DBVerifierLinker] Received command from BungeeCord: " + command);
+            Bukkit.dispatchCommand(Bukkit.getConsoleSender(), command.replaceAll("%player%", name));
         }
 
         if (subChannel.equals("test")) {
-            sendToBungee(player,"test","{\"test\":true}");
+            sendToBungee(player, "test", "{\"test\":true}");
         }
     }
 
@@ -127,15 +140,15 @@ public class DBVerifier extends JavaPlugin implements PluginMessageListener {
         // Player player = Iterables.getFirst(Bukkit.getOnlinePlayers(), null);
         // Else, specify them
         player.sendPluginMessage(this, PLUGIN_CHANNEL_NAME, out.toByteArray());
-
     }
 
     public void loadConfig() {
         File file = new File(getDataFolder().getAbsolutePath(), "config.yml");
-        if(!file.exists()) {
+
+        if (!file.exists()) {
             file.getParentFile().mkdirs();
-            try(InputStream in = getClass().getClassLoader().getResourceAsStream("config.yml")) {
-                Files.copy(in,file.toPath());
+            try (InputStream in = getClass().getClassLoader().getResourceAsStream("config.yml")) {
+                Files.copy(in, file.toPath());
             } catch (IOException e) {
                 e.printStackTrace();
             }
@@ -143,5 +156,4 @@ public class DBVerifier extends JavaPlugin implements PluginMessageListener {
 
         conf = YamlConfiguration.loadConfiguration(file);
     }
-
 }

--- a/bukkit/src/main/java/de/staticred/dbverifier/DBVerifier.java
+++ b/bukkit/src/main/java/de/staticred/dbverifier/DBVerifier.java
@@ -110,7 +110,7 @@ public class DBVerifier extends JavaPlugin implements PluginMessageListener {
             if (useSRV) {
                 verified = srv.getAccountLinkManager().getDiscordId(UUID.fromString(uuid)) == null;
             }
-            if (debugMode) System.out.println("§c[DBVerifierLinker] Send request Answer to BungeeCord");
+            if (debugMode) System.out.println("§c[DBVerifierLinker] Send the response from the request to BungeeCord");
             sendToBungee(player, "requestAnswer", "{\"uuid\": \"" + uuid + "\", \"verified\": " + verified + "}");
         }
 

--- a/bukkit/src/main/resources/config.yml
+++ b/bukkit/src/main/resources/config.yml
@@ -1,1 +1,2 @@
 useSRV: false
+debugMode: false

--- a/bungeecord/pom.xml
+++ b/bungeecord/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.example</groupId>
     <artifactId>DBVerifier-Bungeecord</artifactId>
-    <version>1.6.0</version>
+    <version>1.6.1</version>
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>

--- a/bungeecord/src/main/java/de/staticred/discordbot/bungeecommands/MCVerifyCommandExecutor.java
+++ b/bungeecord/src/main/java/de/staticred/discordbot/bungeecommands/MCVerifyCommandExecutor.java
@@ -14,7 +14,6 @@ import de.staticred.discordbot.util.manager.RewardManager;
 import net.dv8tion.jda.api.entities.Member;
 import net.dv8tion.jda.api.entities.TextChannel;
 import net.dv8tion.jda.api.entities.User;
-import net.dv8tion.jda.api.exceptions.HierarchyException;
 import net.md_5.bungee.api.CommandSender;
 import net.md_5.bungee.api.chat.TextComponent;
 import net.md_5.bungee.api.connection.ProxiedPlayer;
@@ -159,11 +158,7 @@ public class MCVerifyCommandExecutor extends Command {
                 if (m.isOwner()) {
                     p.sendMessage(new TextComponent(DBVerifier.getInstance().getStringFromConfig("MemberIsOwner", false)));
                 } else {
-                    try {
-                        m.getGuild().modifyNickname(m, p.getName()).queue();
-                    } catch (HierarchyException e) {
-                        Debugger.debugMessage("Can't modify a member with higher or equal highest role than the bot! Can't modify " + m.getNickname());
-                    }
+                    m.getGuild().modifyNickname(m, p.getName()).queue();
                 }
 
             }

--- a/bungeecord/src/main/java/de/staticred/discordbot/bungeecommands/MCVerifyCommandExecutor.java
+++ b/bungeecord/src/main/java/de/staticred/discordbot/bungeecommands/MCVerifyCommandExecutor.java
@@ -2,23 +2,19 @@ package de.staticred.discordbot.bungeecommands;
 
 import de.staticred.discordbot.DBVerifier;
 import de.staticred.discordbot.api.EventManager;
-import de.staticred.discordbot.db.RewardsDAO;
-import de.staticred.discordbot.db.VerifyDAO;
 import de.staticred.discordbot.api.event.UserClickedMessageEvent;
 import de.staticred.discordbot.api.event.UserUnverifiedEvent;
 import de.staticred.discordbot.api.event.UserVerifiedEvent;
+import de.staticred.discordbot.db.VerifyDAO;
 import de.staticred.discordbot.files.BlockedServerFileManager;
 import de.staticred.discordbot.files.ConfigFileManager;
 import de.staticred.discordbot.files.DiscordMessageFileManager;
-import de.staticred.discordbot.files.RewardsFileManager;
-import de.staticred.discordbot.util.Debugger;
 import de.staticred.discordbot.util.MemberManager;
+import de.staticred.discordbot.util.manager.RewardManager;
 import net.dv8tion.jda.api.entities.Member;
 import net.dv8tion.jda.api.entities.TextChannel;
 import net.dv8tion.jda.api.entities.User;
-import net.dv8tion.jda.api.exceptions.HierarchyException;
 import net.md_5.bungee.api.CommandSender;
-import net.md_5.bungee.api.ProxyServer;
 import net.md_5.bungee.api.chat.TextComponent;
 import net.md_5.bungee.api.connection.ProxiedPlayer;
 import net.md_5.bungee.api.plugin.Command;
@@ -66,11 +62,7 @@ public class MCVerifyCommandExecutor extends Command {
             Member m = DBVerifier.getInstance().playerMemberHashMap.get(p);
             TextChannel tc = DBVerifier.getInstance().playerChannelHashMap.get(p);
 
-
-
-
             try {
-
                 UserVerifiedEvent event2 = new UserVerifiedEvent(m,p,tc);
                 EventManager.instance.fireEvent(event2);
                 if(event2.isCanceled()) return;
@@ -105,30 +97,7 @@ public class MCVerifyCommandExecutor extends Command {
                 }
             }
 
-
-            try {
-                if(DBVerifier.getInstance().debugMode) Debugger.debugMessage("Checking if player got rewarded");
-                if(!RewardsDAO.INSTANCE.hasPlayerBeenRewarded(p.getUniqueId())) {
-                    if(DBVerifier.getInstance().debugMode) Debugger.debugMessage("Player has not been rewarded or ignoring");
-                    if(DBVerifier.getInstance().debugMode) Debugger.debugMessage("Execute all Bungeecord commands");
-                    for(String command : RewardsFileManager.INSTANCE.getCommandsOnVerifiedBungee()) {
-                        if(DBVerifier.getInstance().debugMode) Debugger.debugMessage("Execute bungeecord cmd: " + command);
-                        ProxyServer.getInstance().getPluginManager().dispatchCommand(ProxyServer.getInstance().getConsole(), command.replace("%player%",p.getName()));
-                    }
-                    if(DBVerifier.getInstance().debugMode) Debugger.debugMessage("Execute all Bukkit commands");
-                    for(String command : RewardsFileManager.INSTANCE.getCommandsOnVerifiedBukkit()) {
-                        DBVerifier.getInstance().bukkitMessageHandler.sendCommand(p,command);
-                        if(DBVerifier.getInstance().debugMode) Debugger.debugMessage("Execute bukkit cmd: " + command);
-                    }
-
-                    if(!ConfigFileManager.INSTANCE.igrnoreRewardState())
-                        RewardsDAO.INSTANCE.setPlayerRewardState(p.getUniqueId(),true);
-                }
-            } catch (SQLException throwables) {
-                throwables.printStackTrace();
-            } catch (HierarchyException e) {
-                Debugger.debugMessage("Can't modify a member with higher or equal highest role than the bot! Can't modify " + m.getNickname());
-            }
+            RewardManager.executeVerifyRewardProcess(p);
 
             p.sendMessage(new TextComponent(DBVerifier.getInstance().getStringFromConfig("Verified",true)));
             return;
@@ -189,11 +158,7 @@ public class MCVerifyCommandExecutor extends Command {
                 if (m.isOwner()) {
                     p.sendMessage(new TextComponent(DBVerifier.getInstance().getStringFromConfig("MemberIsOwner", false)));
                 } else {
-                    try {
-                        m.getGuild().modifyNickname(m, p.getName()).queue();
-                    } catch (HierarchyException e) {
-                        Debugger.debugMessage("Can't modify a member with higher or equal highest role than the bot! Can't modify " + m.getNickname());
-                    }
+                    m.getGuild().modifyNickname(m, p.getName()).queue();
                 }
 
             }
@@ -222,7 +187,7 @@ public class MCVerifyCommandExecutor extends Command {
                 return;
             }
 
-            Member m = null;
+            Member m;
             try {
                 m = MemberManager.getMemberFromPlayer(p.getUniqueId());
             } catch (SQLException throwables) {
@@ -258,24 +223,8 @@ public class MCVerifyCommandExecutor extends Command {
                 return;
             }
 
-            try {
-                if(!RewardsDAO.INSTANCE.hasPlayerBeenRewarded(p.getUniqueId())) {
-                    for(String command2 : RewardsFileManager.INSTANCE.getCommandsOnUnVerifiedBungee()) {
-                        if(DBVerifier.getInstance().debugMode) Debugger.debugMessage("Execute bungeecord cmd: " + command2);
-                        ProxyServer.getInstance().getPluginManager().dispatchCommand(ProxyServer.getInstance().getConsole(), command2.replace("%player%",p.getName()));
-                    }
+            RewardManager.executeVerifyUnlinkProcess(p);
 
-                    for(String command2 : RewardsFileManager.INSTANCE.getCommandsOnUnVerifiedBukkit()) {
-                        DBVerifier.getInstance().bukkitMessageHandler.sendCommand(p,command2);
-                        if(DBVerifier.getInstance().debugMode) Debugger.debugMessage("Execute bukkit cmd: " + command2);
-                    }
-
-                    if(!ConfigFileManager.INSTANCE.igrnoreRewardState())
-                        RewardsDAO.INSTANCE.setPlayerRewardState(p.getUniqueId(),true);
-                }
-            } catch (SQLException throwables) {
-                throwables.printStackTrace();
-            }
 
             p.sendMessage(new TextComponent(DBVerifier.getInstance().getStringFromConfig("UnlinkedYourSelf",true)));
             return;

--- a/bungeecord/src/main/java/de/staticred/discordbot/bungeecommands/SetupCommandExecutor.java
+++ b/bungeecord/src/main/java/de/staticred/discordbot/bungeecommands/SetupCommandExecutor.java
@@ -67,7 +67,6 @@ public class SetupCommandExecutor extends Command {
                 DBVerifier.getInstance().settingUp.clear();
                 return;
             }
-            DataBaseConnection.INSTANCE.connect();
             if(DBVerifier.getInstance().useSRV) {
                 sender.sendMessage(new TextComponent("§aNow let´s test the SRV connection"));
                 sender.sendMessage(new TextComponent("§aTesting Connection:"));

--- a/bungeecord/src/main/java/de/staticred/discordbot/bungeecommands/dbcommand/DBCommandExecutor.java
+++ b/bungeecord/src/main/java/de/staticred/discordbot/bungeecommands/dbcommand/DBCommandExecutor.java
@@ -63,10 +63,10 @@ public class DBCommandExecutor extends Command {
         }
 
         sender.sendMessage(new TextComponent("§8---§aDCVerifier§8---"));
-        sender.sendMessage(new TextComponent("§a/db reload &7- &eReload all files."));
-        sender.sendMessage(new TextComponent("§a/db debug &7- &eTurn on/off debug mode."));
-        sender.sendMessage(new TextComponent("§a/db info &7- &eGives all information of from a linked player."));
-        sender.sendMessage(new TextComponent("§a/db unlink &7- &eUnlinks a player."));
-        sender.sendMessage(new TextComponent("§a/db update &7- &eForce a player rankupdate."));
+        sender.sendMessage(new TextComponent("§a/db reload §7- §eReload all files."));
+        sender.sendMessage(new TextComponent("§a/db debug §7- §eTurn on/off debug mode."));
+        sender.sendMessage(new TextComponent("§a/db info §7- §eGives all information of from a linked player."));
+        sender.sendMessage(new TextComponent("§a/db unlink §7- §eUnlinks a player."));
+        sender.sendMessage(new TextComponent("§a/db update §7- §eForce a player rankupdate."));
     }
 }

--- a/bungeecord/src/main/java/de/staticred/discordbot/bungeecommands/dbcommand/subcommands/DBUnlinkSubCommand.java
+++ b/bungeecord/src/main/java/de/staticred/discordbot/bungeecommands/dbcommand/subcommands/DBUnlinkSubCommand.java
@@ -5,8 +5,11 @@ import de.staticred.discordbot.db.VerifyDAO;
 import de.staticred.discordbot.util.MemberManager;
 import de.staticred.discordbot.util.SubCommand;
 import de.staticred.discordbot.util.UUIDFetcher;
+import de.staticred.discordbot.util.manager.RewardManager;
 import net.md_5.bungee.api.CommandSender;
+import net.md_5.bungee.api.ProxyServer;
 import net.md_5.bungee.api.chat.TextComponent;
+import net.md_5.bungee.api.connection.ProxiedPlayer;
 
 import java.sql.SQLException;
 import java.util.UUID;
@@ -53,8 +56,13 @@ public class DBUnlinkSubCommand extends SubCommand {
             return;
         }
 
+        ProxiedPlayer target = ProxyServer.getInstance().getPlayer(uuid);
+
+        if(target != null) RewardManager.executeVerifyUnlinkProcess(target);
+
         try {
             VerifyDAO.INSTANCE.setPlayerAsUnVerified(uuid);
+            VerifyDAO.INSTANCE.removeDiscordID(uuid);
             DBVerifier.getInstance().removeAllRolesFromMember(MemberManager.getMemberFromPlayer(uuid));
             sender.sendMessage(new TextComponent(DBVerifier.getInstance().getStringFromConfig("UnlinkedPlayer",true)));
         } catch (SQLException e) {

--- a/bungeecord/src/main/java/de/staticred/discordbot/db/RewardsDAO.java
+++ b/bungeecord/src/main/java/de/staticred/discordbot/db/RewardsDAO.java
@@ -5,6 +5,7 @@ import de.staticred.discordbot.files.ConfigFileManager;
 import de.staticred.discordbot.files.VerifyFileManager;
 import de.staticred.discordbot.util.Debugger;
 
+import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -21,15 +22,13 @@ public class RewardsDAO {
         }
 
 
-        DataBaseConnection con = DataBaseConnection.INSTANCE;
         if(DBVerifier.getInstance().debugMode) Debugger.debugMessage("Opening DB Connection from: RewardsDAO.loadTable");
-        con.executeUpdate("CREATE TABLE IF NOT EXISTS rewards(UUID VARCHAR(36) PRIMARY KEY, playerRewarded BOOLEAN)");
+        DataBaseConnection.INSTANCE.executeUpdate("CREATE TABLE IF NOT EXISTS rewards(UUID VARCHAR(36) PRIMARY KEY, playerRewarded BOOLEAN)");
     }
 
     public void addPlayerAsUnRewarded(UUID player) throws SQLException {
-        DataBaseConnection con = DataBaseConnection.INSTANCE;
         if(DBVerifier.getInstance().debugMode) Debugger.debugMessage("Opening DB Connection from: RewardsDAO.addPlayerAsUnRewarded ");
-        con.executeUpdate("INSERT INTO rewards(UUID, playerRewarded) VALUES(?,?)", player.toString(), 0);
+        DataBaseConnection.INSTANCE.executeUpdate("INSERT INTO rewards(UUID, playerRewarded) VALUES(?,?)", player.toString(), 0);
     }
 
     public void setPlayerRewardState(UUID player, boolean state) throws SQLException {
@@ -39,9 +38,8 @@ public class RewardsDAO {
             return;
         }
 
-        DataBaseConnection con = DataBaseConnection.INSTANCE;
         if(DBVerifier.getInstance().debugMode) Debugger.debugMessage("Opening DB Connection from: RewardsDAO.setPlayerRewardState");
-        con.executeUpdate("UPDATE rewards SET playerRewarded = ? WHERE UUID = ?", state, player.toString());
+        DataBaseConnection.INSTANCE.executeUpdate("UPDATE rewards SET playerRewarded = ? WHERE UUID = ?", state, player.toString());
     }
 
     public boolean isPlayerInTable(UUID player) throws SQLException {
@@ -50,9 +48,9 @@ public class RewardsDAO {
             return true;
         }
 
-        DataBaseConnection con = DataBaseConnection.INSTANCE;
+        Connection con = DataBaseConnection.INSTANCE.dataSource.getConnection();
         if(DBVerifier.getInstance().debugMode) Debugger.debugMessage("Opening DB Connection from: RewardsDAO.isPlayerInTable");
-        PreparedStatement ps = con.getConnection().prepareStatement("SELECT * FROM rewards WHERE UUID = ?");
+        PreparedStatement ps = con.prepareStatement("SELECT * FROM rewards WHERE UUID = ?");
         ps.setString(1, player.toString());
 
         ResultSet rs = ps.executeQuery();
@@ -60,10 +58,12 @@ public class RewardsDAO {
         if(rs.next()) {
             ps.close();
             rs.close();
+            con.close();
             return true;
         }
         ps.close();
         rs.close();
+        con.close();
         return false;
     }
 
@@ -77,9 +77,9 @@ public class RewardsDAO {
             return VerifyFileManager.INSTANCE.getRewardState(player);
         }
 
-        DataBaseConnection con = DataBaseConnection.INSTANCE;
+        Connection con = DataBaseConnection.INSTANCE.dataSource.getConnection();
         if(DBVerifier.getInstance().debugMode) Debugger.debugMessage("Opening DB Connection from: RewardsDAO.hasPlayerBeenRewarded");
-        PreparedStatement ps = con.getConnection().prepareStatement("SELECT * FROM rewards WHERE UUID = ? AND playerRewarded = 1");
+        PreparedStatement ps = con.prepareStatement("SELECT * FROM rewards WHERE UUID = ? AND playerRewarded = 1");
         ps.setString(1, player.toString());
 
         ResultSet rs = ps.executeQuery();
@@ -87,10 +87,12 @@ public class RewardsDAO {
         if(rs.next()) {
             ps.close();
             rs.close();
+            con.close();
             return true;
         }
         ps.close();
         rs.close();
+        con.close();
         return false;
     }
 }

--- a/bungeecord/src/main/java/de/staticred/discordbot/discordcommands/UnlinkCommandExecutor.java
+++ b/bungeecord/src/main/java/de/staticred/discordbot/discordcommands/UnlinkCommandExecutor.java
@@ -7,6 +7,7 @@ import de.staticred.discordbot.files.ConfigFileManager;
 import de.staticred.discordbot.files.DiscordMessageFileManager;
 import de.staticred.discordbot.files.RewardsFileManager;
 import de.staticred.discordbot.util.Debugger;
+import de.staticred.discordbot.util.manager.RewardManager;
 import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.entities.Member;
 import net.dv8tion.jda.api.entities.Message;
@@ -91,42 +92,11 @@ public class UnlinkCommandExecutor {
 
             if(DBVerifier.getInstance().debugMode) Debugger.debugMessage("Executing reward process");
 
-
-            try {
-                if(!RewardsDAO.INSTANCE.hasPlayerBeenRewarded(uuid)) {
-                    for(String command2 : RewardsFileManager.INSTANCE.getCommandsOnUnVerifiedBungee()) {
-                        if(DBVerifier.getInstance().debugMode) Debugger.debugMessage("Execute bungeecord cmd: " + command2);
-                        ProxyServer.getInstance().getPluginManager().dispatchCommand(ProxyServer.getInstance().getConsole(), command2.replace("%player%",name));
-                    }
-
-                    for(String command2 : RewardsFileManager.INSTANCE.getCommandsOnUnVerifiedBukkit()) {
-                        DBVerifier.getInstance().bukkitMessageHandler.sendCommand(player,command2);
-                        if(DBVerifier.getInstance().debugMode) Debugger.debugMessage("Execute bukkit cmd: " + command2);
-                    }
-
-                    if(!ConfigFileManager.INSTANCE.igrnoreRewardState())
-                        RewardsDAO.INSTANCE.setPlayerRewardState(uuid,true);
-                }
-            } catch (SQLException throwables) {
-                throwables.printStackTrace();
-            }
+            RewardManager.executeVerifyUnlinkProcess(player);
         }else{
-            if(DBVerifier.getInstance().debugMode) Debugger.debugMessage("Player is not on the network");
-            if(DBVerifier.getInstance().debugMode) Debugger.debugMessage("Executing reward process");
-            try {
-                if(!RewardsDAO.INSTANCE.hasPlayerBeenRewarded(uuid)) {
-                    for(String command2 : RewardsFileManager.INSTANCE.getCommandsOnUnVerifiedBungee()) {
-                        if(DBVerifier.getInstance().debugMode) Debugger.debugMessage("Execute bungeecord cmd: " + command2);
-                        ProxyServer.getInstance().getPluginManager().dispatchCommand(ProxyServer.getInstance().getConsole(), command2.replace("%player%",name));
-                    }
-                    if(DBVerifier.getInstance().debugMode) Debugger.debugMessage("Can't execute bukkit command if the user is offline from the network.");
-                    if(!ConfigFileManager.INSTANCE.igrnoreRewardState())
-                        RewardsDAO.INSTANCE.setPlayerRewardState(uuid,true);
-                }
-            } catch (SQLException throwables) {
-                throwables.printStackTrace();
-            }
 
+
+            RewardManager.executeVerifyUnlinkProcessBungeeCord(name);
             Debugger.debugMessage("A member unlinked himself from a account which is not present on the network. The player will get unlinked on the next reconnect.");
         }
 

--- a/bungeecord/src/main/java/de/staticred/discordbot/discordevents/GuildLeftEvent.java
+++ b/bungeecord/src/main/java/de/staticred/discordbot/discordevents/GuildLeftEvent.java
@@ -1,21 +1,24 @@
 package de.staticred.discordbot.discordevents;
 
 import de.staticred.discordbot.db.VerifyDAO;
+import de.staticred.discordbot.util.Debugger;
+import de.staticred.discordbot.util.manager.RewardManager;
 import net.dv8tion.jda.api.entities.Member;
-import net.dv8tion.jda.api.events.guild.member.GuildMemberLeaveEvent;
+import net.dv8tion.jda.api.events.guild.member.GuildMemberRemoveEvent;
 import net.dv8tion.jda.api.hooks.ListenerAdapter;
 
 import java.sql.SQLException;
 
 public class GuildLeftEvent extends ListenerAdapter {
 
-
-    public void onGuildMemberLeave(GuildMemberLeaveEvent e) {
+    public void onGuildMemberRemove(GuildMemberRemoveEvent e) {
+        Debugger.debugMessage("Member " + e.getMember().getEffectiveName() + " left the server.");
         Member m = e.getMember();
         try {
+            RewardManager.executeVerifyUnlinkProcessBungeeCord(VerifyDAO.INSTANCE.getName(m.getId()));
+            VerifyDAO.INSTANCE.setPlayerAsUnverified(m.getId());
             VerifyDAO.INSTANCE.removeDiscordIDByDiscordID(m);
-        } catch (
-                SQLException ex) {
+        } catch (SQLException ex) {
             ex.printStackTrace();
         }
     }

--- a/bungeecord/src/main/java/de/staticred/discordbot/files/VerifyFileManager.java
+++ b/bungeecord/src/main/java/de/staticred/discordbot/files/VerifyFileManager.java
@@ -7,9 +7,9 @@ import net.md_5.bungee.config.Configuration;
 import net.md_5.bungee.config.ConfigurationProvider;
 import net.md_5.bungee.config.YamlConfiguration;
 
+import java.awt.*;
 import java.io.File;
 import java.io.IOException;
-import java.util.List;
 import java.util.UUID;
 
 public class VerifyFileManager {
@@ -56,6 +56,8 @@ public class VerifyFileManager {
     public UUID getUUIDByPlayerName(String name) {
 
         Debugger.debugMessage("Iterating UUID from verify.yml");
+
+
 
         for(String iteradedUUID : conf.getKeys()) {
             Debugger.debugMessage("found " + iteradedUUID);
@@ -136,6 +138,12 @@ public class VerifyFileManager {
     public void removeDiscordID(ProxiedPlayer p) {
         removeDiscordIDUUIDLink(getDiscordID(p.getUniqueId()));
         conf.set(p.getUniqueId().toString() + ".discordid","nothing");
+        saveFile();
+    }
+
+    public void removeDiscordID(UUID p) {
+        removeDiscordIDUUIDLink(getDiscordID(p));
+        conf.set(p.toString() + ".discordid","nothing");
         saveFile();
     }
 

--- a/bungeecord/src/main/java/de/staticred/discordbot/util/Debugger.java
+++ b/bungeecord/src/main/java/de/staticred/discordbot/util/Debugger.java
@@ -8,13 +8,13 @@ import net.md_5.bungee.api.connection.ProxiedPlayer;
 public class Debugger {
 
     public static void debugMessage(String string) {
+        if(!DBVerifier.getInstance().debugMode) return;
+
         System.out.println("[DBVerifier] [DEBUG] " + string);
         if(!DBVerifier.getInstance().debugMode) return;
         for(ProxiedPlayer player : ProxyServer.getInstance().getPlayers()) {
             if(player.hasPermission("db.debug") || player.hasPermission("db.*")) {
-                if(DBVerifier.getInstance().debugMode) {
-                    player.sendMessage(new TextComponent("§8[§aDBVerifier§8] [§aDEBUG§8] §r" + string));
-                }
+                player.sendMessage(new TextComponent("§8[§aDBVerifier§8] [§aDEBUG§8] §r" + string));
             }
         }
     }

--- a/bungeecord/src/main/java/de/staticred/discordbot/util/FileAndDataBaseManager.java
+++ b/bungeecord/src/main/java/de/staticred/discordbot/util/FileAndDataBaseManager.java
@@ -1,0 +1,30 @@
+package de.staticred.discordbot.util;
+
+import de.staticred.discordbot.files.*;
+
+public class FileAndDataBaseManager {
+
+    public static void loadAllFilesAndDatabases() {
+
+        ConfigFileManager.INSTANCE.loadFile();
+
+        VerifyFileManager.INSTANCE.loadFile();
+
+        MessagesFileManager.INSTANCE.loadFile();
+
+        DiscordFileManager.INSTANCE.loadFile();
+
+        RewardsFileManager.INSTANCE.loadFile();
+
+        BlockedServerFileManager.INSTANCE.loadFile();
+
+        DiscordMessageFileManager.INSTANCE.loadFile();
+
+        SettingsFileManager.INSTANCE.loadFile();
+
+        DiscordFileManager.INSTANCE.update();
+
+        AliasesFileManager.INSTANCE.loadFile();
+    }
+
+}

--- a/bungeecord/src/main/java/de/staticred/discordbot/util/manager/RewardManager.java
+++ b/bungeecord/src/main/java/de/staticred/discordbot/util/manager/RewardManager.java
@@ -1,0 +1,83 @@
+package de.staticred.discordbot.util.manager;
+
+import de.staticred.discordbot.DBVerifier;
+import de.staticred.discordbot.db.RewardsDAO;
+import de.staticred.discordbot.db.VerifyDAO;
+import de.staticred.discordbot.files.ConfigFileManager;
+import de.staticred.discordbot.files.RewardsFileManager;
+import de.staticred.discordbot.util.Debugger;
+import net.md_5.bungee.api.ProxyServer;
+import net.md_5.bungee.api.connection.ProxiedPlayer;
+
+import java.sql.SQLException;
+
+public class RewardManager {
+
+
+    public static void executeVerifyRewardProcess(ProxiedPlayer p) {
+        try {
+            if(!RewardsDAO.INSTANCE.hasPlayerBeenRewarded(p.getUniqueId())  || ConfigFileManager.INSTANCE.igrnoreRewardState()) {
+                for(String command2 : RewardsFileManager.INSTANCE.getCommandsOnVerifiedBungee()) {
+                    if(DBVerifier.getInstance().debugMode) Debugger.debugMessage("Execute bungeecord cmd: " + command2);
+                    ProxyServer.getInstance().getPluginManager().dispatchCommand(ProxyServer.getInstance().getConsole(), command2.replace("%player%",p.getName()));
+                }
+
+                for(String command2 : RewardsFileManager.INSTANCE.getCommandsOnVerifiedBukkit()) {
+                    DBVerifier.getInstance().bukkitMessageHandler.sendCommand(p,command2);
+                    if(DBVerifier.getInstance().debugMode) Debugger.debugMessage("Execute bukkit cmd: " + command2);
+                }
+
+                if(!ConfigFileManager.INSTANCE.igrnoreRewardState())
+                    RewardsDAO.INSTANCE.setPlayerRewardState(p.getUniqueId(),true);
+            }
+        } catch (
+                SQLException throwables) {
+            throwables.printStackTrace();
+        }
+
+    }
+
+    public static void executeVerifyUnlinkProcess(ProxiedPlayer p) {
+        try {
+            if(!RewardsDAO.INSTANCE.hasPlayerBeenRewarded(p.getUniqueId()) || ConfigFileManager.INSTANCE.igrnoreRewardState()) {
+                for(String command2 : RewardsFileManager.INSTANCE.getCommandsOnUnVerifiedBungee()) {
+                    if(DBVerifier.getInstance().debugMode) Debugger.debugMessage("Execute bungeecord cmd: " + command2);
+                    ProxyServer.getInstance().getPluginManager().dispatchCommand(ProxyServer.getInstance().getConsole(), command2.replace("%player%",p.getName()));
+                }
+
+                for(String command2 : RewardsFileManager.INSTANCE.getCommandsOnUnVerifiedBukkit()) {
+                    DBVerifier.getInstance().bukkitMessageHandler.sendCommand(p,command2);
+                    if(DBVerifier.getInstance().debugMode) Debugger.debugMessage("Execute bukkit cmd: " + command2);
+                }
+
+                if(!ConfigFileManager.INSTANCE.igrnoreRewardState())
+                    RewardsDAO.INSTANCE.setPlayerRewardState(p.getUniqueId(),true);
+            }
+        } catch (
+                SQLException throwables) {
+            throwables.printStackTrace();
+        }
+
+    }
+
+    public static void executeVerifyUnlinkProcessBungeeCord(String name) {
+        try {
+
+            if(!RewardsDAO.INSTANCE.hasPlayerBeenRewarded(VerifyDAO.INSTANCE.getUUIDByName(name)) || ConfigFileManager.INSTANCE.igrnoreRewardState()) {
+                for(String command2 : RewardsFileManager.INSTANCE.getCommandsOnUnVerifiedBungee()) {
+                    if(DBVerifier.getInstance().debugMode) Debugger.debugMessage("Execute bungeecord cmd: " + command2);
+                    ProxyServer.getInstance().getPluginManager().dispatchCommand(ProxyServer.getInstance().getConsole(), command2.replace("%player%",name));
+                }
+
+                if(!ConfigFileManager.INSTANCE.igrnoreRewardState())
+                    RewardsDAO.INSTANCE.setPlayerRewardState(VerifyDAO.INSTANCE.getUUIDByName(name), true);
+            }
+        } catch (
+                SQLException throwables) {
+            throwables.printStackTrace();
+        }
+
+    }
+
+
+}

--- a/bungeecord/src/main/resources/plugin.yml
+++ b/bungeecord/src/main/resources/plugin.yml
@@ -1,4 +1,4 @@
 name: DBVerifier
-version: 1.6.0
+version: 1.6.1
 author: staticfx
 main: de.staticred.discordbot.DBVerifier


### PR DESCRIPTION
The error "Error occurred while enabling DBVerifierLinker v1.0.0 (Is it up to date?)
3 java.lang.NoClassDefFoundError: github/scarsz/discordsrv/DiscordSRV" is not print in the console, now it prints the message "[DBVerifierLinker] DiscordSRV is not installed!". I add a debug mode to remove unessecary prints for normal user.