### PR TITLE
(Bugfix) NPE on change server

### DIFF
--- a/bukkit/pom.xml
+++ b/bukkit/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.example</groupId>
     <artifactId>DBV-Bukkit-Extension</artifactId>
-    <version>1.6.5</version>
+    <version>1.6.6</version>
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>

--- a/bukkit/src/main/resources/plugin.yml
+++ b/bukkit/src/main/resources/plugin.yml
@@ -1,4 +1,4 @@
 name: DBVerifierLinker
-version: 1.6.5
+version: 1.6.6
 author: StaticRed
 main: de.staticred.dbverifier.DBVerifier

--- a/bungeecord/pom.xml
+++ b/bungeecord/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.example</groupId>
     <artifactId>DBVerifier-Bungeecord</artifactId>
-    <version>1.6.5</version>
+    <version>1.6.6</version>
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>

--- a/bungeecord/src/main/java/de/staticred/discordbot/DBVerifier.java
+++ b/bungeecord/src/main/java/de/staticred/discordbot/DBVerifier.java
@@ -84,7 +84,7 @@ public class DBVerifier extends Plugin {
 
     //the version of the internal file system
     public final static String configVersion = "1.6.1";
-    public final static String msgVersion = "1.6.5";
+    public final static String msgVersion = "1.6.6";
     public final static String dcMSGVersion  = "1.6.1";
 
     public static String pluginVersion;

--- a/bungeecord/src/main/java/de/staticred/discordbot/bungeeevents/ChangedBukkitServerEvent.java
+++ b/bungeecord/src/main/java/de/staticred/discordbot/bungeeevents/ChangedBukkitServerEvent.java
@@ -28,7 +28,7 @@ public class ChangedBukkitServerEvent implements Listener {
 
         if(switcher == null) return;
 
-        if(DBVerifier.getInstance().playerSRVVerifiedHashMap.containsKey(switcher.getUniqueId())) return;
+        if(!DBVerifier.getInstance().playerSRVVerifiedHashMap.containsKey(switcher.getUniqueId())) return;
 
         if(!ConfigFileManager.INSTANCE.useSRV()) return;
         

--- a/bungeecord/src/main/resources/MinecraftMessages.yml
+++ b/bungeecord/src/main/resources/MinecraftMessages.yml
@@ -39,4 +39,4 @@ GroupDeleted: "§cThe given group got deleted."
 AcceptMessage: "&a&lAccept"
 DeclineMessage: "&c&lDecline"
 Unverfied: "&cYour mc account was unverified, because your discord account was not found on the guild!"
-version: 1.6.5
+version: 1.6.6

--- a/bungeecord/src/main/resources/plugin.yml
+++ b/bungeecord/src/main/resources/plugin.yml
@@ -1,4 +1,4 @@
 name: DBVerifier
-version: 1.6.5
+version: 1.6.6
 author: StaticRed
 main: de.staticred.discordbot.DBVerifier


### PR DESCRIPTION
Fixes the following:
```
[22:43:22 ERROR]: Task BungeeTask(sched=net.md_5.bungee.scheduler.BungeeScheduler@35a80a70, id=1140799, owner=de.staticred.discordbot.DBVerifier@c5324529, task=de.staticred.discordbot.bungeeevents.ChangedBukkitServerEvent$$Lambda$1980/0x00000000802d6010@a731b14b, delay=2000, period=0, running=true) encountered an exception
java.lang.NullPointerException: null
        at de.staticred.discordbot.bungeeevents.ChangedBukkitServerEvent.lambda$onServerChange$0(ChangedBukkitServerEvent.java:41) ~[?:?]
        at de.staticred.discordbot.bungeeevents.ChangedBukkitServerEvent$$Lambda$1980/0x00000000802d6010.run(Unknown Source) ~[?:?]
        at net.md_5.bungee.scheduler.BungeeTask.run(BungeeTask.java:66) ~[server.jar:git:Travertine-Bootstrap:1.16-R0.4-SNAPSHOT:72c234b:unknown]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149) ~[?:1.8.0_275]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624) ~[?:1.8.0_275
```